### PR TITLE
Allow creation of a Uuid on subclasses

### DIFF
--- a/src/UuidExtension.php
+++ b/src/UuidExtension.php
@@ -32,7 +32,7 @@ class UuidExtension extends DataExtension
         $uuid = Uuid::uuid4();
         if ($check) {
             $schema = DataObjectSchema::create();
-            $table = $schema->tableName(get_class($this->owner));
+            $table = $schema->tableForField(get_class($this->owner), 'Uuid');
             do {
                 $this->owner->Uuid = $uuid->getBytes();
                 // If we have something, keep checking


### PR DESCRIPTION
If the Uuid field is defined on a base class, the table for the field is not the same as the table for the class of the `DataObject` being created. We must make sure we're checking for the correct table.